### PR TITLE
Normalize whitespace in a smarter way

### DIFF
--- a/hasql-interpolate.cabal
+++ b/hasql-interpolate.cabal
@@ -19,22 +19,7 @@ description:
   snippets. A number of type classes are also provided to reduce
   encoder/decoder boilerplate.
 
-library
-    exposed-modules:  Hasql.Interpolate
-                      Hasql.Interpolate.Internal.TH
-
-    other-modules:    Hasql.Interpolate.Internal.Json
-                      Hasql.Interpolate.Internal.Encoder
-                      Hasql.Interpolate.Internal.Decoder
-                      Hasql.Interpolate.Internal.OneColumn
-                      Hasql.Interpolate.Internal.OneRow
-                      Hasql.Interpolate.Internal.RowsAffected
-                      Hasql.Interpolate.Internal.Decoder.TH
-                      Hasql.Interpolate.Internal.Sql
-                      Hasql.Interpolate.Internal.CompositeValue
-                      Hasql.Interpolate.Internal.EncodeRow
-                      Hasql.Interpolate.Internal.EncodeRow.TH
-
+common component
     build-depends:    aeson ^>= 1.5 || ^>= 2.0 || ^>= 2.1 || ^>= 2.2,
                       array ^>= 0.5,
                       base
@@ -79,9 +64,26 @@ library
                       transformers ^>= 0.5 || ^>= 0.6,
                       uuid ^>= 1.3,
                       vector ^>= 0.11 || ^>= 0.12 || ^>= 0.13,
+    default-language: Haskell2010
+
+library
+    import: component
+    exposed-modules:  Hasql.Interpolate
+                      Hasql.Interpolate.Internal.TH
+
+    other-modules:    Hasql.Interpolate.Internal.Json
+                      Hasql.Interpolate.Internal.Encoder
+                      Hasql.Interpolate.Internal.Decoder
+                      Hasql.Interpolate.Internal.OneColumn
+                      Hasql.Interpolate.Internal.OneRow
+                      Hasql.Interpolate.Internal.RowsAffected
+                      Hasql.Interpolate.Internal.Decoder.TH
+                      Hasql.Interpolate.Internal.Sql
+                      Hasql.Interpolate.Internal.CompositeValue
+                      Hasql.Interpolate.Internal.EncodeRow
+                      Hasql.Interpolate.Internal.EncodeRow.TH
 
     hs-source-dirs:   lib
-    default-language: Haskell2010
     ghc-options:
       -Wall
       -Wcompat
@@ -93,15 +95,25 @@ library
       -O2
 
 test-suite unit
+  import: component
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  build-depends: base
-               , hasql ^>= 1.10
-               , hasql-interpolate
-               , template-haskell
-               , tasty
-               , text
+  build-depends:
+                 tasty
                , tasty-hunit
                , tmp-postgres >= 1.34.1.0
-  hs-source-dirs: test
-  default-language: Haskell2010
+  hs-source-dirs: lib, test
+  other-modules:
+    Hasql.Interpolate
+    Hasql.Interpolate.Internal.CompositeValue
+    Hasql.Interpolate.Internal.Decoder
+    Hasql.Interpolate.Internal.Decoder.TH
+    Hasql.Interpolate.Internal.EncodeRow
+    Hasql.Interpolate.Internal.EncodeRow.TH
+    Hasql.Interpolate.Internal.Encoder
+    Hasql.Interpolate.Internal.Json
+    Hasql.Interpolate.Internal.OneColumn
+    Hasql.Interpolate.Internal.OneRow
+    Hasql.Interpolate.Internal.RowsAffected
+    Hasql.Interpolate.Internal.Sql
+    Hasql.Interpolate.Internal.TH

--- a/lib/Hasql/Interpolate/Internal/TH.hs
+++ b/lib/Hasql/Interpolate/Internal/TH.hs
@@ -263,24 +263,6 @@ normalizeWhitespace = \case
   x : xs -> x : normalizeWhitespace xs
   "" -> ""
 
--- Drop trailing whitespace except one.
-dropTrailingWhitespace :: String -> String
-dropTrailingWhitespace = foldr go []
-  where
-    go x acc
-      | isSpace x = case acc of
-          [] -> [' ']
-          xs@[' '] -> xs
-          xs -> x:xs -- we are no longer at tail
-      | otherwise = x:acc
-
--- Drop leading whiltespace except one.
-dropLeadingWhitespace :: String -> String
-dropLeadingWhitespace s@(x:xs)
-  | isSpace x = ' ' : dropWhile isSpace xs
-  | otherwise = s
-dropLeadingWhitespace [] = []
-
 addParam :: State Int Builder
 addParam = state \i ->
   let !i' = i + 1
@@ -288,8 +270,7 @@ addParam = state \i ->
 
 parseSqlExpr :: String -> Either (ParseErrorBundle String Void) SqlExpr
 parseSqlExpr str = do
-  ps <- runParser (execStateT sqlExprParser (ParserState id id id 0)) ""
-    (dropLeadingWhitespace $ dropTrailingWhitespace str)
+  ps <- runParser (execStateT sqlExprParser (ParserState id id id 0)) "" str
   pure
     SqlExpr
       { sqlBuilderExp = ps'sqlBuilderExp ps [],

--- a/lib/Hasql/Interpolate/Internal/TH.hs
+++ b/lib/Hasql/Interpolate/Internal/TH.hs
@@ -48,6 +48,7 @@ import Text.Megaparsec
     notFollowedBy,
     runParser,
     single,
+    takeWhile1P,
     takeWhileP,
     try,
   )
@@ -67,6 +68,7 @@ data SqlBuilderExp
   | Sbe'Ident String
   | Sbe'DollarQuote String String
   | Sbe'Cquote String
+  | Sbe'Whitespace
   | Sbe'Sql String
   deriving stock (Show, Eq)
 
@@ -94,6 +96,9 @@ sq = "'"
 dq :: Builder
 dq = "\""
 
+space :: Builder
+space = " "
+
 data ParserState = ParserState
   { ps'sqlBuilderExp :: [SqlBuilderExp] -> [SqlBuilderExp],
     ps'paramEncoder :: [ParamEncoder] -> [ParamEncoder],
@@ -115,6 +120,7 @@ sqlExprParser = go
         <|> splice
         <|> comment
         <|> multilineComment
+        <|> whitespace
         <|> someSql
         <|> eof
 
@@ -245,23 +251,24 @@ sqlExprParser = go
         '^',
         '$',
         '-',
-        '/'
+        '/',
+        ' ',
+        '\t',
+        '\n',
+        '\f',
+        '\r'
       ]
+
+    whitespace = do
+      _ <- takeWhile1P (Just "whitespace") isSpace
+      appendSqlBuilderExp Sbe'Whitespace
+      go
 
     someSql = do
       s <- anySingle
       content <- takeWhileP (Just "sql") (\c -> IS.notMember (fromEnum c) breakCharsIS)
-      appendSqlBuilderExp (Sbe'Sql (normalizeWhitespace (s : content)))
+      appendSqlBuilderExp (Sbe'Sql (s : content))
       go
-
--- Everywhere in a string, collapse consecutive runs of whitespace to a single space
---
--- normalizeWhitespace "   foo\n  \n   \n \t\t bar   " = " foo bar "
-normalizeWhitespace :: String -> String
-normalizeWhitespace = \case
-  x : xs | isSpace x -> ' ' : normalizeWhitespace (dropWhile isSpace xs)
-  x : xs -> x : normalizeWhitespace xs
-  "" -> ""
 
 addParam :: State Int Builder
 addParam = state \i ->
@@ -326,6 +333,7 @@ compileSqlExpr (SqlExpr sqlBuilder enc spliceBindings bindCount) = do
           Sbe'Ident content -> [e|pure (dq <> Builder.fromString content <> dq) <> $b|]
           Sbe'DollarQuote tag content -> [e|pure (dollar <> Builder.fromString tag <> dollar <> Builder.fromString content <> dollar <> Builder.fromString tag <> dollar) <> $b|]
           Sbe'Cquote content -> [e|pure (cquote <> content <> sq) <> $b|]
+          Sbe'Whitespace -> [e|pure space <> $b|]
           Sbe'Sql content -> [e|pure (Builder.fromString content) <> $b|]
      in foldr go [e|pure mempty|] sqlBuilder
   encExp <-

--- a/lib/Hasql/Interpolate/Internal/TH.hs
+++ b/lib/Hasql/Interpolate/Internal/TH.hs
@@ -326,16 +326,17 @@ compileSqlExpr (SqlExpr sqlBuilder enc spliceBindings bindCount) = do
           )
           spliceBindings
   sqlBuilderExp <-
-    let go a b = case a of
-          Sbe'Var i -> [e|Ap $(varE (nameArr ! i)) <> $b|]
-          Sbe'Param -> [e|Ap addParam <> $b|]
-          Sbe'Quote content -> [e|pure (sq <> Builder.fromString content <> sq) <> $b|]
-          Sbe'Ident content -> [e|pure (dq <> Builder.fromString content <> dq) <> $b|]
-          Sbe'DollarQuote tag content -> [e|pure (dollar <> Builder.fromString tag <> dollar <> Builder.fromString content <> dollar <> Builder.fromString tag <> dollar) <> $b|]
-          Sbe'Cquote content -> [e|pure (cquote <> content <> sq) <> $b|]
-          Sbe'Whitespace -> [e|pure space <> $b|]
-          Sbe'Sql content -> [e|pure (Builder.fromString content) <> $b|]
-     in foldr go [e|pure mempty|] sqlBuilder
+    let go :: SqlBuilderExp -> (Q Exp, Bool) -> (Q Exp, Bool)
+        go a (b, omitWhitespace) = case a of
+          Sbe'Var i -> ([e|Ap $(varE (nameArr ! i)) <> $b|], False)
+          Sbe'Param -> ([e|Ap addParam <> $b|], False)
+          Sbe'Quote content -> ([e|pure (sq <> Builder.fromString content <> sq) <> $b|], False)
+          Sbe'Ident content -> ([e|pure (dq <> Builder.fromString content <> dq) <> $b|], False)
+          Sbe'DollarQuote tag content -> ([e|pure (dollar <> Builder.fromString tag <> dollar <> Builder.fromString content <> dollar <> Builder.fromString tag <> dollar) <> $b|], undefined)
+          Sbe'Cquote content -> ([e|pure (cquote <> content <> sq) <> $b|], False)
+          Sbe'Whitespace -> (if omitWhitespace then b else [e|pure space <> $b|], True)
+          Sbe'Sql content -> ([e|pure (Builder.fromString content) <> $b|], False)
+     in fst (foldr go ([e|pure mempty|], False) sqlBuilder)
   encExp <-
     let go a b = case a of
           Pe'Exp x -> [e|($(pure x) >$ E.param encodeField) <> $b|]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -70,13 +70,13 @@ testParseQuotes = do
   let expected = SqlExpr expectedSqlExpr [] [] 0
       expectedSqlExpr =
         [ Sbe'Quote "#{bonk}",
-          Sbe'Sql " ",
+          Sbe'Whitespace,
           Sbe'Quote "^{z''onk}",
-          Sbe'Sql " ",
+          Sbe'Whitespace,
           Sbe'Ident "#{k\"\"onk}",
-          Sbe'Sql " ",
+          Sbe'Whitespace,
           Sbe'DollarQuote "tag" "#{kiplonk}",
-          Sbe'Sql " ",
+          Sbe'Whitespace,
           Sbe'Cquote "newline \\n escaped \\'string\\'"
         ]
   parseSqlExpr "'#{bonk}' '^{z''onk}' \"#{k\"\"onk}\" $tag$#{kiplonk}$tag$ E'newline \\n escaped \\'string\\''" @?= Right expected
@@ -85,10 +85,17 @@ testParseComment :: IO ()
 testParseComment = do
   let expected = SqlExpr expectedSqlExpr [] [] 0
       expectedSqlExpr =
-        [ Sbe'Sql "content ",
-          Sbe'Sql " hello ",
-          Sbe'Sql " world ",
-          Sbe'Sql " end "
+        [ Sbe'Sql "content",
+          Sbe'Whitespace,
+          Sbe'Whitespace,
+          Sbe'Sql "hello",
+          Sbe'Whitespace,
+          Sbe'Whitespace,
+          Sbe'Sql "world",
+          Sbe'Whitespace,
+          Sbe'Whitespace,
+          Sbe'Sql "end",
+          Sbe'Whitespace
         ]
       inputStr =
         unlines
@@ -104,7 +111,7 @@ testParseEndComment :: IO ()
 testParseEndComment = do
   let expected = SqlExpr expectedSqlExpr [] [] 0
       expectedSqlExpr =
-        [ Sbe'Sql "select 1 ", Sbe'Sql " " ]
+        [ Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace, Sbe'Whitespace ]
       inputStr =
         unlines
           [ "select 1 ",
@@ -117,8 +124,11 @@ testParseEndMultiComment :: IO ()
 testParseEndMultiComment = do
   let expected = SqlExpr expectedSqlExpr [] [] 0
       expectedSqlExpr =
-        [ Sbe'Sql "select 1 ",
-          Sbe'Sql " "
+        [ Sbe'Sql "select",
+          Sbe'Whitespace,
+          Sbe'Sql "1",
+          Sbe'Whitespace,
+          Sbe'Whitespace
         ]
       inputStr =
         unlines
@@ -135,7 +145,7 @@ testParseParam :: IO ()
 testParseParam = do
   let expected =
         SqlExpr
-          [Sbe'Param, Sbe'Sql " ", Sbe'Param]
+          [Sbe'Param, Sbe'Whitespace, Sbe'Param]
           [Pe'Exp (VarE (mkName "x")), Pe'Exp (LitE (IntegerL 2))]
           []
           0
@@ -198,11 +208,11 @@ testSnippet getDb = do
 
 testNormalizeWhitespace :: IO ()
 testNormalizeWhitespace = do
-    let t actual expected = parseSqlExpr actual @?= Right (SqlExpr [Sbe'Sql expected] [] [] 0)
-    t "select 1   " "select 1 "
-    t "   select 1" " select 1"
-    t "select  1" "select 1"
-    t "\n  select  1  \n  where  true  \n  " " select 1 where true "
+    let t actual expected = parseSqlExpr actual @?= Right (SqlExpr expected [] [] 0)
+    t "select 1   " [Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace]
+    t "   select 1" [Sbe'Whitespace, Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1"]
+    t "select  1" [Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1"]
+    t "\n  select  1  \n  where  true  \n  " [Sbe'Whitespace, Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace, Sbe'Sql "where", Sbe'Whitespace, Sbe'Sql "true", Sbe'Whitespace]
 
 withLocalTransaction :: IO Tmp.DB -> (Hasql.Connection.Connection -> IO a) -> IO a
 withLocalTransaction getDb k =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,17 +11,21 @@
 module Main where
 
 import Control.Exception
+import Control.Monad.Trans.State.Strict (evalState)
 import Data.Int
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as Builder
 import qualified Database.Postgres.Temp as Tmp
 import GHC.Generics (Generic)
 import qualified Hasql.Connection
 import qualified Hasql.Connection.Settings
 import Hasql.Decoders (column)
 import Hasql.Interpolate
+import Hasql.Interpolate.Internal.Sql
 import Hasql.Interpolate.Internal.TH
 import qualified Hasql.Session
 import Language.Haskell.TH
@@ -83,35 +87,21 @@ testParseQuotes = do
 
 testParseComment :: IO ()
 testParseComment = do
-  let expected = SqlExpr expectedSqlExpr [] [] 0
-      expectedSqlExpr =
-        [ Sbe'Sql "content",
-          Sbe'Whitespace,
-          Sbe'Whitespace,
-          Sbe'Sql "hello",
-          Sbe'Whitespace,
-          Sbe'Whitespace,
-          Sbe'Sql "world",
-          Sbe'Whitespace,
-          Sbe'Whitespace,
-          Sbe'Sql "end",
-          Sbe'Whitespace
-        ]
-      inputStr =
-        unlines
-          [ "content -- trailing comment",
-            "hello /* / comment * */ world",
-            "/* comment",
-            "blerg /* nested comment */",
-            "*/ end"
-          ]
-  parseSqlExpr inputStr @?= Right expected
+  sqlToText
+    [sql|
+      content -- trailing comment
+      hello /* / comment * */ world
+      /* comment
+      blerg /* nested comment */
+      */ end
+    |]
+    @?= " content hello world end "
 
 testParseEndComment :: IO ()
 testParseEndComment = do
   let expected = SqlExpr expectedSqlExpr [] [] 0
       expectedSqlExpr =
-        [ Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace, Sbe'Whitespace ]
+        [Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace, Sbe'Whitespace]
       inputStr =
         unlines
           [ "select 1 ",
@@ -122,24 +112,15 @@ testParseEndComment = do
 
 testParseEndMultiComment :: IO ()
 testParseEndMultiComment = do
-  let expected = SqlExpr expectedSqlExpr [] [] 0
-      expectedSqlExpr =
-        [ Sbe'Sql "select",
-          Sbe'Whitespace,
-          Sbe'Sql "1",
-          Sbe'Whitespace,
-          Sbe'Whitespace
-        ]
-      inputStr =
-        unlines
-          [ "select 1",
-            "\n",
-            "/* comment",
-            "blerg ",
-            "*/",
-            "\n\n"
-          ]
-  parseSqlExpr inputStr @?= Right expected
+  sqlToText
+    [sql|
+      select 1
+      /* comment
+      blerg
+      */
+
+    |]
+    @?= " select 1 "
 
 testParseParam :: IO ()
 testParseParam = do
@@ -208,11 +189,17 @@ testSnippet getDb = do
 
 testNormalizeWhitespace :: IO ()
 testNormalizeWhitespace = do
-    let t actual expected = parseSqlExpr actual @?= Right (SqlExpr expected [] [] 0)
-    t "select 1   " [Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace]
-    t "   select 1" [Sbe'Whitespace, Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1"]
-    t "select  1" [Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1"]
-    t "\n  select  1  \n  where  true  \n  " [Sbe'Whitespace, Sbe'Sql "select", Sbe'Whitespace, Sbe'Sql "1", Sbe'Whitespace, Sbe'Sql "where", Sbe'Whitespace, Sbe'Sql "true", Sbe'Whitespace]
+  let t actual expected = parseSqlExpr actual @?= Right (SqlExpr expected [] [] 0)
+  sqlToText [sql|select 1   |] @?= "select 1 "
+  sqlToText [sql|   select 1|] @?= " select 1"
+  sqlToText [sql|select  1|] @?= "select 1"
+  sqlToText
+    [sql|
+    select  1
+      where   true
+    |]
+    @?= " select 1 where true "
+  sqlToText ([sql|  select  |] <> [sql|  1  |]) @?= " select  1 "
 
 withLocalTransaction :: IO Tmp.DB -> (Hasql.Connection.Connection -> IO a) -> IO a
 withLocalTransaction getDb k =
@@ -227,11 +214,15 @@ withLocalTransaction getDb k =
             Right () -> pure ()
     bracket beginTrans (\() -> rollbackTrans) \() -> k conn
 
-run :: DecodeResult a => Hasql.Connection.Connection -> Sql -> IO a
+run :: (DecodeResult a) => Hasql.Connection.Connection -> Sql -> IO a
 run conn stmt = do
   Hasql.Connection.use conn (Hasql.Session.statement () (interp False stmt)) >>= \case
     Left err -> assertFailure ("Hasql statement unexpectedly failed with error: " <> show err)
     Right x -> pure x
+
+sqlToText :: Sql -> Text
+sqlToText (Sql bldr _) =
+  TL.toStrict $ Builder.toLazyText $ evalState bldr 1
 
 data Point = Point Int32 Int32
   deriving stock (Generic, Eq, Show)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -104,7 +104,7 @@ testParseEndComment :: IO ()
 testParseEndComment = do
   let expected = SqlExpr expectedSqlExpr [] [] 0
       expectedSqlExpr =
-        [ Sbe'Sql "select 1 " ]
+        [ Sbe'Sql "select 1 ", Sbe'Sql " " ]
       inputStr =
         unlines
           [ "select 1 ",


### PR DESCRIPTION
This PR refactors the existing whitespace normalization (recently fixed by @sopvop, thank you!) to be a bit more principled. Rather than parse non-identifier, non-string sql fragments into a catch-all `Sbe'Sql` variant, then try to normalize the whitespace within, we just parse whitespase as a `Sbe'Whitespace` variant. Consecutive whitespace results in a single `Sbe'Whitespace` node, and consecutive `Sbe'Whitespace` (as can happen via whitespace -> comment (stripped) -> whitespace) are treated as a single `Sbe'Whitespace` while rendering. As before, you can still end up with leading and trailing whitespace on a query sent to Postgres, and an arbitrary amount of consecutive whitespace, because of `<>`. There is of course an encoding of `SqlBuilderExp` that would allow us to maximally normalize whitespace, but the existing code (and this refactoring) still do a pretty good job of making queries in logs more readable.

cc @sopvop, any thoughts on this change?