### PR TITLE
Swap haskell-src-meta for ghc-hs-meta to fix OverloadedRecordDot in splices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Switch splice parser from `haskell-src-meta` to `ghc-hs-meta`. The previous parser silently misparsed `OverloadedRecordDot` syntax inside `#{...}` splices (e.g. `#{user.name}`) as the function-composition operator, leading to confusing type errors or wrong queries. The new parser uses GHC's own frontend with `OverloadedRecordDot`, `OverloadedLabels`, `OverloadedRecordUpdate`, and `TypeApplications` enabled, emitting `TH.GetFieldE` directly. Splice consumers using `#{x.y}` need `OverloadedRecordDot` enabled in their own module. Now requires GHC ≥ 9.2 (for `template-haskell-2.18`).
+
 ## [1.1.0.1] – April 14, 2026
 
 * Fix bug in normalizing whitespace

--- a/hasql-interpolate.cabal
+++ b/hasql-interpolate.cabal
@@ -33,7 +33,7 @@ common component
                         || ^>= 4.21,
                       bytestring ^>= 0.11.2.0 || ^>= 0.12,
                       containers ^>= 0.5 || ^>= 0.6 || ^>= 0.7 || ^>= 0.8,
-                      haskell-src-meta ^>= 0.8,
+                      ghc-hs-meta ^>= 0.1.5,
                       hasql ^>= 1.10,
                       iproute ^>= 1.7,
                       megaparsec

--- a/lib/Hasql/Interpolate/Internal/TH.hs
+++ b/lib/Hasql/Interpolate/Internal/TH.hs
@@ -35,7 +35,7 @@ import Data.Void
 import qualified Hasql.Encoders as E
 import Hasql.Interpolate.Internal.Encoder (EncodeField (..))
 import Hasql.Interpolate.Internal.Sql
-import Language.Haskell.Meta (parseExp)
+import Language.Haskell.Meta.Parse (parseExp)
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 import Text.Megaparsec
@@ -225,7 +225,7 @@ sqlExprParser = go
       _ <- single '}'
       alpha <-
         case parseExp content of
-          Left err -> fail err
+          Left (line, col, err) -> fail (show line <> ":" <> show col <> ": " <> err)
           Right x -> pure x
       appendEncoder (Pe'Exp alpha)
       appendSqlBuilderExp Sbe'Param
@@ -237,7 +237,7 @@ sqlExprParser = go
       _ <- single '}'
       alpha <-
         case parseExp content of
-          Left err -> fail err
+          Left (line, col, err) -> fail (show line <> ":" <> show col <> ": " <> err)
           Right x -> pure x
       addSpliceBinding alpha
       go

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -53,7 +53,9 @@ parserTests =
       testCase "end comment" testParseEndComment,
       testCase "end multiline comment" testParseEndMultiComment,
       testCase "param" testParseParam,
-      testCase "whitespace" testNormalizeWhitespace
+      testCase "whitespace" testNormalizeWhitespace,
+      testCase "record-dot in splice" testRecordDot,
+      testCase "chained record-dot in splice" testRecordDotChained
     ]
 
 executionTests :: IO Tmp.DB -> TestTree
@@ -131,6 +133,33 @@ testParseParam = do
           []
           0
   parseSqlExpr "#{x} #{2}" @?= Right expected
+
+-- Regression: OverloadedRecordDot inside #{...}. With the previous
+-- haskell-src-meta/haskell-src-exts parser this misparsed silently as
+-- composition (`pid . toText`); ghc-hs-meta uses GHC's real parser
+-- with OverloadedRecordDot enabled, producing TH's GetFieldE node
+-- directly.
+testRecordDot :: IO ()
+testRecordDot =
+  parseSqlExpr "#{pid.toText}"
+    @?= Right
+      ( SqlExpr
+          [Sbe'Param]
+          [Pe'Exp (GetFieldE (VarE (mkName "pid")) "toText")]
+          []
+          0
+      )
+
+testRecordDotChained :: IO ()
+testRecordDotChained =
+  parseSqlExpr "#{user.project.name}"
+    @?= Right
+      ( SqlExpr
+          [Sbe'Param]
+          [Pe'Exp (GetFieldE (GetFieldE (VarE (mkName "user")) "project") "name")]
+          []
+          0
+      )
 
 testBasic :: IO Tmp.DB -> IO ()
 testBasic getDb = do


### PR DESCRIPTION
Thanks for this library. I use it in https://github.com/monoscope-tech/monoscope and realized I couldn't get overloaded record dot to work properly.

 `haskell-src-exts` predates `OverloadedRecordDot` (GHC 9.2). So writing `#{user.name}` inside a `[sql| ... |]` quasiquoter, the splice parser silently accepts it and lexes the dot as the **composition operator** — so `#{user.name}` parses as `user . name`. This produces either a confusing downstream type error or, if the types happen to align, a wrong query.

This PR replaces `haskell-src-meta` with [`ghc-hs-meta`](https://hackage.haskell.org/package/ghc-hs-meta), which uses GHC's own parser with `OverloadedRecordDot`, `OverloadedLabels`, `OverloadedRecordUpdate`, and `TypeApplications` enabled by default. GHC's parser emits `HsGetField`, which `ghc-hs-meta` translates to Template Haskell's first-class `GetFieldE` node.

Observable change for `#{pid.toText}`:

```diff
- Pe'Exp (UInfixE (VarE pid) (VarE .) (VarE toText))      -- composition (wrong)
+ Pe'Exp (GetFieldE (VarE pid) "toText")                  -- record-dot (correct)
```

## Caveats

- Bumps the implicit GHC lower bound to **9.2** (`template-haskell >= 2.18` for `GetFieldE`).
- Splice consumers writing `#{x.y}` need `OverloadedRecordDot` enabled in their own module — same requirement as writing `x.y` anywhere else in Haskell.
